### PR TITLE
Fix message validation logic in contact form

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -44,8 +44,11 @@ const ContactForm: React.FC = () => {
     } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
       newErrors.email = t('contactForm.emailInvalid');
     }
-    if (!formData.message.trim()) newErrors.message = t('contactForm.messageRequired');
-    if (formData.message.trim().length < 10) newErrors.message = t('contactForm.messageMinLength');
+    if (!formData.message.trim()) {
+      newErrors.message = t('contactForm.messageRequired');
+    } else if (formData.message.trim().length < 10) {
+      newErrors.message = t('contactForm.messageMinLength');
+    }
     if (!formData.consent) newErrors.consent = t('contactForm.consentRequired');
     
     setErrors(newErrors);


### PR DESCRIPTION
## Summary
- prevent overwriting the `messageRequired` error by checking for minimum length only when there is text
- add a trailing newline to `ContactForm.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c01efc674832594aa19ee1ff0f779