### PR TITLE
Remove Basic Auth headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Basic-Auth = "jana:zalogujsiedomnie"
+#    Basic-Auth = "jana:zalogujsiedomnie"

--- a/public/_headers/_headers
+++ b/public/_headers/_headers
@@ -1,2 +1,2 @@
 /*
-  Basic-Auth: Jana zalogujsiedomnie
+#  Basic-Auth: Jana zalogujsiedomnie


### PR DESCRIPTION
## Summary
- comment out Basic-Auth lines in Netlify configuration and headers

## Testing
- `npm install`
- `npm run build`
- `python3 -m http.server 4173 -d dist` and `curl -I http://localhost:4173/`

------
https://chatgpt.com/codex/tasks/task_e_684c04f41bb48325a78ece5e387595f4